### PR TITLE
Change default value of Authority model name property to FQDN

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'nokogiri', '~> 1.8.5'
 gem 'radiodns'
 gem 'roo', '~> 2.7.0'
 gem 'titleize'
-gem 'public_suffix'
 gem 'rubyzip', '~> 1.2.2'
 
 group :development do

--- a/models/authority.rb
+++ b/models/authority.rb
@@ -1,5 +1,4 @@
 require 'radiodns'
-require 'public_suffix'
 require 'titleize'
 require 'net/https'
 require 'uri'
@@ -22,8 +21,7 @@ class Authority < Sequel::Model
     unless self[:name].nil?
       self[:name]
     else
-      domain = PublicSuffix.parse(fqdn)
-      domain.sld.titleize
+      fqdn
     end
   end
 

--- a/spec/authority_spec.rb
+++ b/spec/authority_spec.rb
@@ -19,8 +19,8 @@ describe Authority do
 
     describe "an authority that has no name" do
       let (:authority) { Authority.new(:fqdn => 'rdns.example.com') }
-      it 'extracts the name from the domain name' do
-        expect(authority.name).to eql("Example")
+      it 'returns the FQDN' do
+        expect(authority.name).to eql("rdns.example.com")
       end
     end
   end


### PR DESCRIPTION
Deriving the name of an authority from the FQDN, when no name is provided in the SI, may lead to confusing results.

As the name is not explicitly defined, it might be preferred to use the full FQDN in place of reformatting the domain to a "name"?

This commit changes that behaviour if it's decided to be a better compromise.